### PR TITLE
ZON-5945: Activate PUR for framebuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 2.6.0
+- Add pur gate
+
 ### 2.5.2
 - Fix Cookiebanner w/o Ads
 


### PR DESCRIPTION
### Wasn das?
Einfacher Rückbau des Ausblenden von Anzeigen und gleichzeitige Einführer des neuen Rahmenparameter `pur`.

### Wie testen
Lokal über `/wp-admin/options-general.php?page=zon_get_frame_from_api` den Rahmen neu ziehen. In de `wp-config.php` kann ein Debugparameter gesetzt werden, der den Redirect ausschaltet:

```php
/** deactivate pur gate for tests and on local  */
define('DEACTIVATE_PUR_GATE', true);
```

Sinnvoll, da lokal Cookies nicht regelmäßig funktionieren. Zum testen weglassen oder auf `false` setzen. Dann greift das Mock-JS der lokalen ZON-Testumgebung. Richtiges Testen, vor allem mit fastly leider erst auf Staging möglich.

### Benötigt zusätzlich
https://github.com/ZeitOnline/zon-blog-extensions/pull/3